### PR TITLE
fix(payment): fix promo code input

### DIFF
--- a/src/pages/Payment/index.js
+++ b/src/pages/Payment/index.js
@@ -204,7 +204,7 @@ export default function Payment({ navigation }) {
 
         <PromoCode>
           <Input
-            editable={false}
+            editable={!applied}
             label="Promo code"
             autoCorrect={false}
             autoCapitalize="none"


### PR DESCRIPTION
The promo code input was disabled all the time, so it was impossible to apply it to the account.
This commit makes the input be disabled only after the client apply the promo code to the account.